### PR TITLE
Fix to use p2 instead of p1

### DIFF
--- a/isosurfaces/isoline.py
+++ b/isosurfaces/isoline.py
@@ -180,7 +180,7 @@ class Triangulator:
 
     def get_edge_dual(self, p1: ValuedPoint, p2: ValuedPoint) -> ValuedPoint:
         """Returns the dual point on an edge p1--p2"""
-        if (p1.val > 0) != (p1.val > 0):
+        if (p1.val > 0) != (p2.val > 0):
             # The edge crosses the isoline, so take the midpoint
             return ValuedPoint.midpoint(p1, p2, self.fn)
         dt = 0.01


### PR DESCRIPTION

Old:
```
(p1.val > 0) != (p1.val > 0) # checking the same thing!
```

New:
```
(p1.val > 0) != (p2.val > 0)
```